### PR TITLE
fix(130845): use Operation field for Simnet Key Value writes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import {
   SeatalkNetworkGroup,
   SeatalkDisplayColor,
   SimnetDisplayGroup,
+  SimnetKeyOperation,
   SimnetNightModeColor,
   convertCamelCase
 } from '@canboat/ts-pgns'
@@ -629,8 +630,7 @@ export default function (app: any) {
         new PGN_130845_SimnetKeyValue({
           displayGroup: simradDisplayGroups[group],
           key: 'Backlight level',
-          spare9: 0,
-          minlength: 1,
+          operation: SimnetKeyOperation.Set,
           value: value * 100
         })
       )
@@ -658,8 +658,7 @@ export default function (app: any) {
         new PGN_130845_SimnetKeyValue({
           displayGroup: simradDisplayGroups[group],
           key: 'Night mode',
-          spare9: 0,
-          minlength: 1,
+          operation: SimnetKeyOperation.Set,
           value: value == 1 ? 4 : 2
         })
       )
@@ -687,8 +686,7 @@ export default function (app: any) {
         new PGN_130845_SimnetKeyValue({
           displayGroup: simradDisplayGroups[group],
           key: 'Night mode color',
-          spare9: 0,
-          minlength: 1,
+          operation: SimnetKeyOperation.Set,
           value: simradDisplayNightColors[value]
         })
       )


### PR DESCRIPTION
## Why this build is red

canboat [#697](https://github.com/canboat/canboat/pull/697) reshaped PGN **130845 Simnet: Key Value**: field 9 was renamed `MinLength` → `Operation` (a `SIMNET_KEY_OPERATION` lookup: `0 Read`, `1 Set`, `2 Reply`) and the `spare9` field was dropped.

After `@canboat/ts-pgns` is regenerated from the new `canboat.json`, `PGN_130845_SimnetKeyValueCreateArgs` no longer has `spare9`/`minlength`, so `src/index.ts` fails to compile:

```
src/index.ts(632,11): error TS2345: ... 'spare9' does not exist in type 'PGN_130845_SimnetKeyValueCreateArgs'.
src/index.ts(661,11): error TS2345: ...
src/index.ts(690,11): error TS2345: ...
```

This surfaces in the canboat repo's "Test canboatjs, ts-pgns and related Signal K projects" workflow, which builds this plugin against the freshly generated types.

## The fix

Replace `spare9: 0` / `minlength: 1` with `operation: SimnetKeyOperation.Set` in the three Simrad display write commands (brightness, night mode, night color), and import `SimnetKeyOperation`. `Set` encodes to wire byte `0x01` — the same byte these commands previously emitted — so on-wire behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)