### PR TITLE
Fix Raymarine night mode color handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -197,7 +197,7 @@ export default function (app: any) {
             values: [
               {
                 path,
-                value: 'day1'
+                value: props.raymarineDayColor || 'day1'
               }
             ],
             meta: [
@@ -304,19 +304,7 @@ export default function (app: any) {
         'vessels.self',
         path,
         (context: string, path: string, value: any, cb: any) => {
-          setRaymarineDisplayColor(group, value === 1 ? 'red/black' : 'day1')
-          app.handleMessage(plugin.id, {
-            updates: [
-              {
-                values: [
-                  {
-                    path,
-                    value: value
-                  }
-                ]
-              }
-            ]
-          })
+          setRaymarineDisplayNightMode(group, Number(value))
           const mapping = props.groupMappings.find((mapping: any) => {
             return mapping.raymarineGroup === group
           })
@@ -604,22 +592,31 @@ export default function (app: any) {
   }
 
   function setRaymarineDisplayNightMode (group: string, value: number) {
-    const dayColor = props.raymarineDayColor || 'day1'
-    const nightColor = props.raymarineNightColor || 'red/black'
-    setRaymarineDisplayColor(group, value === 1 ? nightColor : dayColor)
-    app.handleMessage(plugin.id, {
-      updates: [
-        {
-          values: [
-            {
-              path: `electrical.displays.raymarine.${group}.nightMode.state`,
-              value: value
-            }
-          ]
-        }
-      ]
-    })
-  }
+  value = Number(value)
+
+  const dayColor = props.raymarineDayColor || 'day1'
+  const nightColor = props.raymarineNightColor || 'red/black'
+  const color = value === 1 ? nightColor : dayColor
+
+  setRaymarineDisplayColor(group, color)
+
+  app.handleMessage(plugin.id, {
+    updates: [
+      {
+        values: [
+          {
+            path: `electrical.displays.raymarine.${group}.nightMode.state`,
+            value: value
+          },
+          {
+            path: `electrical.displays.raymarine.${group}.color`,
+            value: color
+          }
+        ]
+      }
+    ]
+  })
+}
 
   function setSimradDisplayBrightness (group: string, value: number) {
     app.emit(


### PR DESCRIPTION
This fixes Raymarine night mode color handling (as mentioned in #14 ).

The current `nightMode.state` PUT handler hard-codes the Raymarine colors to:

```
1 → red/black
0 → day1
```

This ignores the configured plugin values `raymarineNightColor` and `raymarineDayColor`.
The plugin already has `setRaymarineDisplayNightMode(...)`, which uses the configured values, so the PUT handler should call that helper instead of calling `setRaymarineDisplayColor(...)` with hard-coded colors.

**Changes**

- Use `setRaymarineDisplayNightMode(group, Number(value))` in the Raymarine `nightMode.state` PUT handler.
- Update the Raymarine `color` Signal K path when night mode changes.
- Initialize the Raymarine `color` path from `props.raymarineDayColor || 'day1'` instead of always using `day1`.

**Why**

With this change, a configuration such as:
```
Raymarine Night Color: red/black
Raymarine Day Color: inverse
```
behaves as expected:
```
nightMode.state = 1 → color = red/black
nightMode.state = 0 → color = inverse
```
The Signal K data tree also remains consistent because the selected color is reflected in:
`electrical.displays.raymarine.<group>.color`

**Tested**

Tested locally on an OpenPlotter / Signal K / Raymarine installation using `signalk-send-put`.

Verified:
```
electrical.displays.raymarine.cockpit.nightMode.state = 1
→ electrical.displays.raymarine.cockpit.color = red/black

electrical.displays.raymarine.cockpit.nightMode.state = 0
→ electrical.displays.raymarine.cockpit.color = inverse
```